### PR TITLE
Linux ALSA support

### DIFF
--- a/main.py
+++ b/main.py
@@ -90,6 +90,9 @@ def scrape_and_alarm(headers_path):
                     os.system('say "Open slots found"')
             except Exception as _:
                 # No beep for windows
+                # Beep for Linux ALSA
+                import os
+                os.system("speaker-test -t sine -f 1000 -l 1 & sleep .9 && kill -9 $!")
                 pass
 
         logger.info(


### PR DESCRIPTION
The beep works in Linux now using alsa-utils. The beep was not working before. On Android Termux the package sox must be installed and the os line changed to `play -q -n synth 1 sine 1000 vol 0.1`. This line is working on Linux but the sox package is usually not installed as alsa-utils is by default. Sox should work on macos too. Closes #4 